### PR TITLE
switch from gdax to Coinbase Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CryptoTrader by [Haschek Solutions](https://haschek.solutions)
 
 # What does it do?
-The heart of this repo is the ```gdax.php``` file which is a simple implementation of the [GDAX](https://www.gdax.com) API written in PHP.
+The heart of this repo is the ```coinbase-pro.php``` file which is a simple implementation of the [Coinbase Pro](https://pro.coinbase.com/) API written in PHP.
 
 The aim for this project is to create various tools and bots to make trading easier. It doesn't rely on any external APIs or classes rather than php-curl.
 
@@ -10,10 +10,11 @@ ONLY RUN THIS IF YOU KNOW WHAT YOU ARE DOING. IF YOU LOSE MONEY BECAUSE OF A PRO
 # Install
 - Clone this repo or [download the zip file](https://github.com/HaschekSolutions/cryptotrader/archive/master.zip)
 - Rename ```example.config.inc.php``` to ```config.inc.php```
-- Create an API key on https://www.gdax.com/settings/api and fill in the values in your ```config.inc.php``` file
+- Create an API key on https://pro.coinbase.com/profile/api and fill in the values in your ```config.inc.php``` file
 - Install PHP
   - Windows: [Download from windows.php.net](http://windows.php.net/downloads/releases/php-7.2.2-Win32-VC15-x64.zip)
   - Linux: ```apt-get install php5``` or better yet ```apt-get install php7.1``` if available
+  - MacOS: [Install homebrew](https://brew.sh/) and then ```brew update``` followed by ```brew upgrade php```. Apple is not including PHP in future versions of MacOS. If it is missing ```brew install php```. 
 - Run a bot or the example scripts with php
 
 ![API key generation](https://www.pictshare.net/as17pqcsf8.jpg)

--- a/bots/uptrendsurfer.php
+++ b/bots/uptrendsurfer.php
@@ -22,8 +22,8 @@
 *
 */
 
-include_once(dirname(__FILE__).'/../gdax.php');
-$g = new gdax(GDAX_KEY,GDAX_SECRET,GDAX_PASSPHRASE);
+include_once(dirname(__FILE__).'/../coinbaseExchange.php');
+$g = new coinbaseExchange(CB_KEY,CB_SECRET,CB_PASSPHRASE);
 
 // check arguments and stuff
 $args = getArgs(array('p','bw','g','sim','nib','fip'));

--- a/bots/waverider.php
+++ b/bots/waverider.php
@@ -24,8 +24,8 @@
 *
 */
 
-include_once(dirname(__FILE__).'/../gdax.php');
-$g = new gdax(GDAX_KEY,GDAX_SECRET,GDAX_PASSPHRASE);
+include_once(dirname(__FILE__).'/../coinbase-pro.php');
+$g = new coinbaseExchange(CB_KEY,CB_SECRET,CB_PASSPHRASE);
 
 // check arguments and stuff
 $args = getArgs(array('p','bw','g','sim','nib','pv','fip'));

--- a/coinbase-pro.php
+++ b/coinbase-pro.php
@@ -1,19 +1,19 @@
-<?php 
+<?php
 define('DS', DIRECTORY_SEPARATOR);
 define('ROOT', dirname(__FILE__));
 error_reporting(E_ALL & ~E_NOTICE);
 
-if(!file_exists(ROOT.DS.'config.inc.php')) die('Rename example.config.inc.php to config.inc.php before running');
 include_once(ROOT.DS.'config.inc.php');
 
-/* Written in accordance to https://docs.gdax.com/ 
+/* Written in accordance to https://docs.pro.coinbase.com/ 
  Author: Christian Haschek <christian@haschek.at>
  Github repo: https://github.com/HaschekSolutions/cryptotrader
  June 2017
 */
-class gdax 
+
+class CoinbaseExchange
 {
-    private $apiurl = "https://api.gdax.com";
+    private $apiurl = "https://api.pro.coinbase.com";
     private $key;
     private $secret;
     private $passphrase;
@@ -33,7 +33,7 @@ class gdax
         $this->passphrase = $passphrase;
 
         if($sandbox===true)
-            $this->apiurl = "https://api-public.sandbox.gdax.com";
+            $this->apiurl = "https://api-public.sandbox.pro.coinbase.com";
     }
 
     function updatePrices($product='BTC-USD')
@@ -235,12 +235,14 @@ class gdax
         }
         else return $json;
     }
-
-    /*taken from https://docs.gdax.com/#signing-a-message*/
+    
     public function signature($request_path='', $body='', $timestamp=false, $method='GET') {
         $body = is_array($body) ? json_encode($body) : $body;
         $timestamp = $timestamp ? $timestamp : time();
-        return base64_encode(hash_hmac("sha256", $timestamp.$method.$request_path.$body, base64_decode($this->secret), true));
+
+        $what = $timestamp.$method.$request_path.$body;
+
+        return base64_encode(hash_hmac("sha256", $what, base64_decode($this->secret), true));
     }
 }
 

--- a/example.config.inc.php
+++ b/example.config.inc.php
@@ -1,9 +1,9 @@
 <?php 
 date_default_timezone_set('UTC');
 
-// enter key, secret and passphrase from GDAX
+// enter key, secret and passphrase from Coinbase Pro
 // get them from:
-//          https://www.gdax.com/settings/api
-define('GDAX_KEY','');
-define('GDAX_SECRET','');
-define('GDAX_PASSPHRASE','');
+//          https://pro.coinbase.com/profile/api
+define('CB_KEY','your key here');
+define('CB_SECRET','your secret here');
+define('CB_PASSPHRASE','your passphrase here');

--- a/examples/account_info.php
+++ b/examples/account_info.php
@@ -1,7 +1,7 @@
 <?php 
 
-include_once(dirname(__FILE__).'/../gdax.php');
+include_once(dirname(__FILE__).'/../coinbase-pro.php');
 
-$g = new gdax(GDAX_KEY,GDAX_SECRET,GDAX_PASSPHRASE);
+$g = new coinbaseExchange(CB_KEY,CB_SECRET,CB_PASSPHRASE);
 $g->loadAccounts();
 $g->printAccountInfo();

--- a/examples/price_check.php
+++ b/examples/price_check.php
@@ -1,7 +1,7 @@
 <?php 
 
-include_once(dirname(__FILE__).'/../gdax.php');
+include_once(dirname(__FILE__).'/../coinbase-pro.php');
 
-$g = new gdax(GDAX_KEY,GDAX_SECRET,GDAX_PASSPHRASE);
+$g = new coinbaseExchange(CB_KEY,CB_SECRET,CB_PASSPHRASE);
 $g->updatePrices('BTC-EUR');
 $g->printPrices('BTC-EUR');

--- a/wip/matt.php
+++ b/wip/matt.php
@@ -25,8 +25,8 @@
 *  sell 10% above the average price).
 */
 
-include_once(dirname(__FILE__).'/../gdax.php');
-$g = new gdax(GDAX_KEY,GDAX_SECRET,GDAX_PASSPHRASE);
+include_once(dirname(__FILE__).'/../coinbase-pro.php');
+$g = new coinbaseExchange(CB_KEY,CB_SECRET,CB_PASSPHRASE);
 
 // check arguments and stuff
 $args = getArgs(array('p','sp'));


### PR DESCRIPTION
Great work on implementing the API. I found it very helpful and thought I might return the favor by updating everything from gdax to coinbase pro. I tested the "examples", but not the "bots" or "wip". The examples worked great.

Almost all of my work was updating URL's and swapping out gdax references for the coinbase pro equivalents. It did feel heavy handed renaming the main file and the main class, but I wanted to be consistent. I also dropped the appropriate MacOS info into the readme.

Sorry I couldn't do this in smaller bites as I now it requires a quick review of almost every file, but again the changes are pretty minor. Hopefully bringing this up to date will keep it more useful for others. Thanks again for putting this together.